### PR TITLE
chore: skip CompletableFuture.get for fjp in StarvationDetectorSpec, #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ project/project/
 .project
 .sbtserver
 .sbtserver.lock
+.bsp
 .cache*
 target
 

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/StarvationDetectorSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/StarvationDetectorSpec.scala
@@ -26,9 +26,9 @@ import akka.diagnostics.StarvationDetector.StarvationDetectorThread
 import scala.concurrent.ExecutionContext
 
 class StarvationDetectorSpec extends AkkaSpec(s"""akka.diagnostics.recorder.enabled = off
-      akka.diagnostics.starvation-detector.check-interval              = 100ms # check more often
+      akka.diagnostics.starvation-detector.check-interval              = 200ms # check more often
       akka.diagnostics.starvation-detector.initial-delay               = 0     # no initial delay
-      akka.diagnostics.starvation-detector.max-delay-warning-threshold = 10ms  # make check tighter
+      akka.diagnostics.starvation-detector.max-delay-warning-threshold = 30ms  # make check tighter
       akka.diagnostics.starvation-detector.warning-interval            = 10s   # must be longer than one antipattern test, so it is reported only once
       custom-fjp-dispatcher {
         type = Dispatcher
@@ -170,7 +170,7 @@ class StarvationDetectorSpec extends AkkaSpec(s"""akka.diagnostics.recorder.enab
       val tmp = File.createTempFile("bigfile", "txt")
       tmp.deleteOnExit()
 
-      val b = new Array[Byte](3000000) // may need tuning depending on how fast your disk is
+      val b = new Array[Byte](9000000) // may need tuning depending on how fast your disk is
       val fos = new FileOutputStream(tmp)
       try fos.write(b)
       finally {

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/StarvationDetectorSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/StarvationDetectorSpec.scala
@@ -117,12 +117,12 @@ class StarvationDetectorSpec extends AkkaSpec(s"""akka.diagnostics.recorder.enab
             }.flatMap(_ => runThunks(remaining - 1))
           else Future.successful(())
 
-        //EventFilter.warning(start = "Exceedingly long scheduling time on ExecutionContext", occurrences = 0).intercept {
-        val numIterations = 10000 // 10000 * 200 tasks, runs in 1.7 seconds on my machine on two threads
+        EventFilter.warning(start = "Exceedingly long scheduling time on ExecutionContext", occurrences = 0).intercept {
+          val numIterations = 10000 // 10000 * 200 tasks, runs in 1.7 seconds on my machine on two threads
 
-        val result = Future.sequence((1 to 200).map(_ => runThunks(numIterations)))
-        Await.result(result, 10.seconds)
-        //}
+          val result = Future.sequence((1 to 200).map(_ => runThunks(numIterations)))
+          Await.result(result, 10.seconds)
+        }
       }
     }
 


### PR DESCRIPTION
Excluding CompletableFuture.get when running with FJP because it creates new threads (without bounds)
for that blocking operation. CompletableFuture.get is still an anti-pattern, but not something the
TSD can find. Tried to set lower bounds with system property
`java.util.concurrent.ForkJoinPool.common.maximumSpares` but that didn't help

Fixes #5
