### PR TITLE
feat: config checker enhancements

### DIFF
--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -481,6 +481,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
     checkProvider() ++
     checkJvmExitOnFatalError() ++
     checkDefaultDispatcherSize() ++
+    checkInternalDispatcherSize ++
     checkDefaultDispatcherType() ++
     checkDispatcherThroughput(defaultDispatcherPath, config.getConfig(defaultDispatcherPath))
   }
@@ -553,6 +554,29 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
           "run on the default-dispatcher because that may starve other tasks.")
       else if (size <= 3)
         warn(checkerKey, path, s"Don't use too small pool size [$size] for the default-dispatcher. ")
+      else Nil
+    }
+
+  private def checkInternalDispatcherSize(): List[ConfigWarning] =
+    ifEnabled("internal-dispatcher-size") { checkerKey =>
+      val path = internalDispatcherPath
+
+      val size = dispatcherPoolSize(config.getConfig(path))
+
+      val availableProcessors = Runtime.getRuntime.availableProcessors
+      if (size > 64 && size > availableProcessors)
+        warn(
+          checkerKey,
+          path,
+          s"Don't use too large pool size [$size] for the internal-dispatcher. " +
+            "Note that the pool size is calculated by ceil(available processors * parallelism-factor), " +
+            "and then bounded by the parallelism-min and parallelism-max values. " +
+            s"This machine has [$availableProcessors] available processors. " +
+            "If you use a large pool size here because of blocking execution you should instead use " +
+            "a dedicated dispatcher to manage blocking tasks/actors. Blocking execution shouldn't " +
+            "run on the internal-dispatcher because that may starve other tasks.")
+      else if (size <= 3)
+        warn(checkerKey, path, s"Don't use too small pool size [$size] for the internal-dispatcher. ")
       else Nil
     }
 

--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -569,12 +569,12 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
           checkerKey,
           path,
           s"Don't use too large pool size [$size] for the internal-dispatcher. " +
-            "Note that the pool size is calculated by ceil(available processors * parallelism-factor), " +
-            "and then bounded by the parallelism-min and parallelism-max values. " +
-            s"This machine has [$availableProcessors] available processors. " +
-            "If you use a large pool size here because of blocking execution you should instead use " +
-            "a dedicated dispatcher to manage blocking tasks/actors. Blocking execution shouldn't " +
-            "run on the internal-dispatcher because that may starve other tasks.")
+          "Note that the pool size is calculated by ceil(available processors * parallelism-factor), " +
+          "and then bounded by the parallelism-min and parallelism-max values. " +
+          s"This machine has [$availableProcessors] available processors. " +
+          "If you use a large pool size here because of blocking execution you should instead use " +
+          "a dedicated dispatcher to manage blocking tasks/actors. Blocking execution shouldn't " +
+          "run on the internal-dispatcher because that may starve other tasks.")
       else if (size <= 3)
         warn(checkerKey, path, s"Don't use too small pool size [$size] for the internal-dispatcher. ")
       else Nil
@@ -791,11 +791,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
     ifEnabled("remote-artery-not-enabled") { checkerKey =>
       val path = "akka.remote.artery.enabled"
       if (!config.getBoolean(path)) {
-        warn(
-          checkerKey,
-          path,
-          "Disabling artery means you are using classic remote which is deprecated in 2.7"
-        )
+        warn(checkerKey, path, "Disabling artery means you are using classic remote which is deprecated in 2.7")
       } else Nil
     }
 

--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -854,7 +854,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
     }
 
   private def checkClusterWatchFailureDetector(): List[ConfigWarning] =
-    ifEnabled("cluster-watch-failure-detector") { checkerKey =>
+    ifEnabled("remote-watch-failure-detector") { checkerKey =>
       val path = "akka.remote.watch-failure-detector"
       if (isClusterConfigAvailable) {
         warn(

--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -680,7 +680,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
       checkFrameSize() ++
       checkRemoteDispatcherSize() ++
       checkArteryNotEnabled ++
-      checkRemoteWatchFailureDetectorWithCluster() //TODO if cluster depends on remote this will warn everytime we use `akka.actor.provider = cluster`?
+      checkRemoteWatchFailureDetectorWithCluster()
     } else Vector.empty[ConfigWarning]
 
   private def checkRemoteDispatcher(): List[ConfigWarning] =
@@ -854,7 +854,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
           checkerKey,
           path,
           "Deploying an actor remotely is deprecated and not supported. As per https://doc.akka.io/docs/akka/current/remoting.html#creating-actors-remotely"
-        ) //TODO add better description?
+        )
       else Nil
     }
 
@@ -882,7 +882,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
         warn(
           checkerKey,
           s"$path.*",
-          "Remote watch failure detector shouldn't be changed when cluster is used." // TODO explain why?
+          "Remote watch failure detector shouldn't be changed when cluster is used."
         )
       } else Nil
     }
@@ -897,7 +897,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
   private def checkCluster(): Vector[ConfigWarning] =
     if (isClusterConfigAvailable) {
       Vector.empty[ConfigWarning] ++
-      checkAutoDown() ++ //TODO move isClusterConfigAvailable to each of the methods below?
+      checkAutoDown() ++
       checkClusterFailureDetector() ++
       checkClusterDispatcher() ++
       checkCreateActorRemotely()

--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -827,7 +827,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
       else Nil
     }
 
-  private def checkPreferClusterThanRemote(): List[ConfigWarning] =
+  private def checkPreferClusterToRemote(): List[ConfigWarning] =
     ifEnabled("remote-prefer-cluster") { checkerKey =>
       val path = "akka.actor.provider"
       if (config.getString(path) == "remote" || config.getString(path) == "akka.remote.RemoteActorRefProvider")

--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -859,7 +859,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
     }
 
   private def checkRemoteWatchFailureDetectorWithCluster(): List[ConfigWarning] =
-    ifEnabled("remote-watch-failure-detector") { checkerKey =>
+    ifEnabled("remote-watch-failure-detector-with-cluster") { checkerKey =>
       val path = "akka.remote.watch-failure-detector"
       val path1 = s"$path.implementation-class"
       val path2 = s"$path.heartbeat-interval"

--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -853,8 +853,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
         warn(
           checkerKey,
           path,
-          "Deploying an actor remotely is deprecated and not supported. As per https://doc.akka.io/docs/akka/current/remoting.html#creating-actors-remotely"
-        )
+          "Deploying an actor remotely is deprecated and not supported. As per https://doc.akka.io/docs/akka/current/remoting.html#creating-actors-remotely")
       else Nil
     }
 
@@ -879,11 +878,7 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
         config.getValue(path8) != reference.getValue(path8)
 
       if (isClusterConfigAvailable && changed) {
-        warn(
-          checkerKey,
-          s"$path.*",
-          "Remote watch failure detector shouldn't be changed when cluster is used."
-        )
+        warn(checkerKey, s"$path.*", "Remote watch failure detector shouldn't be changed when cluster is used.")
       } else Nil
     }
 

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -830,7 +830,7 @@ class ConfigCheckerSpec extends AkkaSpec {
       printDocWarnings(warnings)
       assertCheckerKey(warnings, "remote-prefer-cluster")
       assertPath(warnings, "akka.actor.provider")
-      assertDisabled(c,  "remote-prefer-cluster")
+      assertDisabled(c, "remote-prefer-cluster")
     }
 
     "not warn about the dynamic hostnames when artery is used" in {

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -250,6 +250,23 @@ class ConfigCheckerSpec extends AkkaSpec {
       assertDisabled(c, "default-dispatcher-size")
     }
 
+    "check internal-dispatcher as default-dispatcher is find" in {
+      val c = ConfigFactory
+        .parseString("""
+          |akka.actor.default-dispatcher = {
+          |  type = "Dispatcher"
+          |  # ...
+          |  }
+          |akka.actor.internal-dispatcher = ${akka.actor.default-dispatcher}  """.stripMargin)
+        .resolve()
+        .withFallback(reference)
+
+      val checker = new ConfigChecker(extSys, c, reference)
+      val warnings = checker.check().warnings
+
+      warnings should be(Nil)
+    }
+
     "find internal-dispatcher size issues" in {
       val c = ConfigFactory
         .parseString("""

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -513,10 +513,8 @@ class ConfigCheckerSpec extends AkkaSpec {
       val configs = configStrings.map(c =>
         ConfigFactory
           .parseString(c)
-          .withFallback(
-            ConfigFactory.parseString("""akka.diagnostics.checker.confirmed-power-user-settings =
-            ["akka.remote.watch-failure-detector.unreachable-nodes-reaper-interval"]""")
-          )
+          .withFallback(ConfigFactory.parseString("""akka.diagnostics.checker.confirmed-power-user-settings =
+            ["akka.remote.watch-failure-detector.unreachable-nodes-reaper-interval"]"""))
           .withFallback(defaultRemote))
       configs.zipWithIndex.foreach { case (c, i) =>
         withClue(s"problem with config #${i + 1}") {

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -62,7 +62,7 @@ class ConfigCheckerSpec extends AkkaSpec {
 
   // for copy paste into config-checkers.rst
   def printDocWarnings(warnings: immutable.Seq[ConfigWarning]): Unit = {
-    if (false) // change to true when updating documentation, or debugging
+    if (true) // change to true when updating documentation, or debugging
       warnings.foreach { w =>
         val msg = s"| ${ConfigChecker.format(w)} |"
         val line = Vector.fill(msg.length - 2)("-").mkString("+", "", "+")
@@ -70,7 +70,6 @@ class ConfigCheckerSpec extends AkkaSpec {
         println(msg)
         println(line)
       }
-
   }
 
   "The ConfigChecker" must {
@@ -424,12 +423,12 @@ class ConfigCheckerSpec extends AkkaSpec {
       val warnings = checker.check().warnings
 
       printDocWarnings(warnings)
-      assertCheckerKey(warnings, "remote-watch-failure-detector", "power-user-settings")
+      assertCheckerKey(warnings, "remote-watch-failure-detector-with-cluster", "power-user-settings")
       assertPath(
         warnings,
         "akka.remote.watch-failure-detector.*",
         "akka.remote.watch-failure-detector.acceptable-heartbeat-pause")
-      assertDisabled(c, "remote-watch-failure-detector", "power-user-settings")
+      assertDisabled(c, "remote-watch-failure-detector-with-cluster", "power-user-settings")
     }
 
     "find too many dispatchers" in {

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -516,7 +516,7 @@ class ConfigCheckerSpec extends AkkaSpec {
           .withFallback(
             ConfigFactory.parseString("""akka.diagnostics.checker.confirmed-power-user-settings =
             ["akka.remote.watch-failure-detector.unreachable-nodes-reaper-interval"]""")
-          ) //TODO Q why is this needed if we are not setting it?
+          )
           .withFallback(defaultRemote))
       configs.zipWithIndex.foreach { case (c, i) =>
         withClue(s"problem with config #${i + 1}") {

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -409,7 +409,7 @@ class ConfigCheckerSpec extends AkkaSpec {
       val checker = new ConfigChecker(extSys, c, reference)
       val warnings = checker.check().warnings
 
-      assertCheckerKey(warnings,  "create-actor-remotely")
+      assertCheckerKey(warnings, "create-actor-remotely")
     }
 
     "find checkClusterWatchFailureDetector" in {
@@ -475,14 +475,15 @@ class ConfigCheckerSpec extends AkkaSpec {
     }
 
     "find remote artery disabled" in {
-      val c = ConfigFactory.parseString(
-        """
-          |akka.remote.artery.enabled = false""".stripMargin).withFallback(defaultCluster)
+      val c = ConfigFactory
+        .parseString("""
+          |akka.remote.artery.enabled = false""".stripMargin)
+        .withFallback(defaultCluster)
       val checker = new ConfigChecker(extSys, c, reference)
 
       val warnings = checker.check().warnings
       printDocWarnings(warnings)
-      assertCheckerKey(warnings,"remote-artery-not-enabled")
+      assertCheckerKey(warnings, "remote-artery-not-enabled")
     }
 
     "find suspect remote watch failure detector" in {
@@ -508,7 +509,7 @@ class ConfigCheckerSpec extends AkkaSpec {
           val warnings = checker.check().warnings
           printDocWarnings(warnings)
           assertCheckerKey(warnings, "remote-watch-failure-detector", "power-user-settings", "remote-prefer-cluster")
-          assertDisabled(c, "remote-watch-failure-detector", "power-user-settings","remote-prefer-cluster")
+          assertDisabled(c, "remote-watch-failure-detector", "power-user-settings", "remote-prefer-cluster")
         }
       }
     }
@@ -528,7 +529,7 @@ class ConfigCheckerSpec extends AkkaSpec {
       printDocWarnings(warnings)
       assertPath(warnings, "akka.remote.default-remote-dispatcher", "akka.actor.provider")
       assertCheckerKey(warnings, "default-remote-dispatcher-size", "remote-prefer-cluster")
-      assertDisabled(c, "default-remote-dispatcher-size","remote-prefer-cluster")
+      assertDisabled(c, "default-remote-dispatcher-size", "remote-prefer-cluster")
     }
 
     "recommend against dedicated cluster dispatcher" in {

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -62,7 +62,7 @@ class ConfigCheckerSpec extends AkkaSpec {
 
   // for copy paste into config-checkers.rst
   def printDocWarnings(warnings: immutable.Seq[ConfigWarning]): Unit = {
-    if (true) // change to true when updating documentation, or debugging
+    if (false) // change to true when updating documentation, or debugging
       warnings.foreach { w =>
         val msg = s"| ${ConfigChecker.format(w)} |"
         val line = Vector.fill(msg.length - 2)("-").mkString("+", "", "+")

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -62,7 +62,7 @@ class ConfigCheckerSpec extends AkkaSpec {
 
   // for copy paste into config-checkers.rst
   def printDocWarnings(warnings: immutable.Seq[ConfigWarning]): Unit = {
-    if (false) // change to true when updating documentation, or debugging
+    if (true) // change to true when updating documentation, or debugging
       warnings.foreach { w =>
         val msg = s"| ${ConfigChecker.format(w)} |"
         val line = Vector.fill(msg.length - 2)("-").mkString("+", "", "+")
@@ -451,6 +451,17 @@ class ConfigCheckerSpec extends AkkaSpec {
       paths should not contain "akka.actor.default-dispatcher"
 
       assertDisabled(c, "dispatcher-total-size")
+    }
+
+    "find remote artery disabled" in {
+      val c = ConfigFactory.parseString(
+        """
+          |akka.remote.artery.enabled = false""".stripMargin).withFallback(defaultCluster)
+      val checker = new ConfigChecker(extSys, c, reference)
+
+      val warnings = checker.check().warnings
+      printDocWarnings(warnings)
+      assertCheckerKey(warnings,"remote-artery-not-enabled")
     }
 
     "find suspect remote watch failure detector" in {

--- a/docs/src/main/paradox/config-checker.md
+++ b/docs/src/main/paradox/config-checker.md
@@ -190,6 +190,14 @@ You have a total of [1000] threads in all configured dispatchers. That many thre
 Don't use too large pool size [100] for fork-join pool. Note that the pool size is calculated by ceil(available processors * parallelism-factor), and then bounded by the parallelism-min and parallelism-max values. This machine has [8] available processors. If you use a large pool size here because of blocking execution you should use a thread-pool-executor instead. Related config properties: [my-fjp]. You may disable this check by adding [fork-join-pool-size] to configuration string list akka.diagnostics.checker.disabled-checks.
 ```
 
+### Internal dispatcher size
+
+@@snip [ConfigCheckerSpec.scala](/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala) { #internal-dispatcher-large }
+
+```
+Don't use too large pool size [512] for the internal-dispatcher. Note that the pool size is calculated by ceil(available processors * parallelism-factor), and then bounded by the parallelism-min and parallelism-max values. This machine has [12] available processors. If you use a large pool size here because of blocking execution you should instead use a dedicated dispatcher to manage blocking tasks/actors. Blocking execution shouldn't run on the internal-dispatcher because that may starve other tasks. Related config properties: [akka.actor.internal-dispatcher]. You may disable this check by adding [internal-dispatcher-size] to configuration string list akka.diagnostics.checker.disabled-checks.
+```
+
 ## Failure detectors
 
 There are 3 different failure detectors that monitor remote connections.
@@ -314,7 +322,23 @@ You have configured maximum-frame-size to [2097152 bytes]. We recommend against 
 Don't use too small pool size [1] for the default-remote-dispatcher-size. Related config properties: [akka.remote.default-remote-dispatcher]. You may disable this check by adding [default-remote-dispatcher-size] to configuration string list akka.diagnostics.checker.disabled-checks.
 ```
 
-### 
+### create-actor-remotely 
+
+```
+Deploying an actor remotely is deprecated and not supported. As per https://doc.akka.io/docs/akka/current/remoting.html#creating-actors-remotely Related config properties: [akka.actor.deployment."/...".remote"]. You may disable this check by adding [create-actor-remotely] to configuration string list akka.diagnostics.checker.disabled-checks.
+```
+
+### remote-artery-disabled
+
+```
+Classic remoting is deprecated since Akka 2.6.0 and will be removed in Akka 2.8.0. Use Artery instead. Related config properties: [akka.remote.artery.enabled = false]. Corresponding default values: [akka.remote.artery.enabled = on]. You may disable this check by adding [remote-artery-disabled] to configuration string list akka.diagnostics.checker.disabled-checks.
+```
+
+### remote-prefer-cluster
+
+```
+Some features, such as remote watch, will be unsafe when using remote without Akka Cluster. Related config properties: [akka.actor.provider = akka.remote.RemoteActorRefProvider]. Corresponding default values: [akka.actor.provider = local]. You may disable this check by adding [remote-prefer-cluster] to configuration string list akka.diagnostics.checker.disabled-checks. 
+```
 
 ## More akka-cluster checks
 

--- a/docs/src/main/paradox/config-checker.md
+++ b/docs/src/main/paradox/config-checker.md
@@ -258,6 +258,12 @@ There are a few more checks related to the Remote watch failure detector:
  * sane ratio betwen `heartbeat-interval` and `acceptable-heartbeat-pause`
  * sane relation between `heartbeat-interval` and `unreachable-nodes-reaper-interval`
 
+In case you are using Akka Cluster is not recommended modifying the defaults remote watch failure detector. 
+
+```
+Remote watch failure detector shouldn't be changed when cluster is used. Related config properties: [akka.remote.watch-failure-detector.*]. You may disable this check by adding [remote-watch-failure-detector-with-cluster] to configuration string list akka.diagnostics.checker.disabled-checks.
+```
+
 ## More akka-actor checks
 
 ### actor-ref-provider
@@ -307,6 +313,8 @@ You have configured maximum-frame-size to [2097152 bytes]. We recommend against 
 ```
 Don't use too small pool size [1] for the default-remote-dispatcher-size. Related config properties: [akka.remote.default-remote-dispatcher]. You may disable this check by adding [default-remote-dispatcher-size] to configuration string list akka.diagnostics.checker.disabled-checks.
 ```
+
+### 
 
 ## More akka-cluster checks
 


### PR DESCRIPTION
References #13, #14, and  #17

13: 
- remote deployment
- using remoting without cluster
- remote watch failure detector (shouldn't be used when cluster is used)

14:
- Similar to checkDefaultDispatcherSize

17:
- Good to warn about artery.enabled=false, which means that classic remoting is used. In Akka 2.8.x classic remoting will be removed so good to warn about that already in 2.7.x.
