### PR TITLE
fix: disabled-typo-sections for r2dbc durable state

### DIFF
--- a/akka-diagnostics/src/main/resources/reference.conf
+++ b/akka-diagnostics/src/main/resources/reference.conf
@@ -212,6 +212,10 @@ akka.diagnostics.checker {
     # Even if we add akka-projection-slick and jackson serializer, most are dynamic so easier to add it here
     "akka.projection.slick",
     "akka.serialization.jackson",
+    # no values in reference.conf
+    "akka.persistence.r2dbc.state.additional-columns",
+    "akka.persistence.r2dbc.state.custom-table",
+    "akka.persistence.r2dbc.state.change-handler",
   ]
 }
 #//#config-checker


### PR DESCRIPTION
To avoid reporting false typo warnings for https://github.com/akka/akka-persistence-r2dbc/blob/043bc63b3beb95d8c41944b73fcb36bdada5d9e1/core/src/main/resources/reference.conf#L83-L105