### PR TITLE
fix: Remove hostname check

### DIFF
--- a/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
+++ b/akka-diagnostics/src/main/scala/akka/diagnostics/ConfigChecker.scala
@@ -4,7 +4,6 @@
 
 package akka.diagnostics
 
-import java.net.InetAddress
 import java.util
 import java.util.Locale
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -718,7 +717,6 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
       Vector.empty[ConfigWarning] ++
       checkRemoteDispatcher() ++
       checkRemoteWatchFailureDetector() ++
-      checkHostname() ++
       checkFrameSize() ++
       checkCreateActorRemotely() ++
       checkPreferClusterToRemote() ++
@@ -801,33 +799,6 @@ class ConfigChecker(system: ExtendedActorSystem, config: Config, reference: Conf
         else Nil
 
       List(w1, w2, w3, w4).flatten
-    }
-
-  private def checkHostname(): List[ConfigWarning] =
-    ifEnabled("hostname") { checkerKey =>
-      val path = "akka.remote.artery.enabled"
-      if (config.getBoolean(path)) {
-        // artery
-        config.getString("akka.remote.artery.canonical.hostname") match {
-          case "<getHostAddress>" =>
-            warn(
-              checkerKey,
-              "akka.remote.artery.canonical.hostname",
-              s"hostname is set to <getHostAddress>, which means that `InetAddress.getLocalHost.getHostAddress` " +
-              "will be used to resolve the hostname. That can result in wrong hostname in some environments, " +
-              """such as "127.0.1.1". Define the hostname explicitly instead. """ +
-              s"On this machine `InetAddress.getLocalHost.getHostAddress` is [${InetAddress.getLocalHost.getHostAddress}].")
-          case "<getHostName>" =>
-            warn(
-              checkerKey,
-              "akka.remote.artery.canonical.hostname",
-              s"hostname is set to <getHostName>, which means that `InetAddress.getLocalHost.getHostAddress` " +
-              "will be used to resolve the hostname. That can result in wrong hostname in some environments, " +
-              """such as "127.0.1.1". Define the hostname explicitly instead. """ +
-              s"On this machine `InetAddress.getLocalHost.getHostAddress` is [${InetAddress.getLocalHost.getHostName}].")
-          case _ => Nil
-        }
-      } else Nil
     }
 
   private def checkArteryNotEnabled(): List[ConfigWarning] =

--- a/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
+++ b/akka-diagnostics/src/test/scala/akka/diagnostics/ConfigCheckerSpec.scala
@@ -865,45 +865,6 @@ class ConfigCheckerSpec extends AkkaSpec {
       assertDisabled(c, "remote-prefer-cluster")
     }
 
-    "not warn about the dynamic hostnames when artery is used" in {
-      val config1 = ConfigFactory
-        .parseString("""
-       akka {
-         actor {
-           provider = remote
-         }
-         remote {
-           artery {
-             enabled = on
-             canonical.hostname = "<getHostAddress>"
-             canonical.port = 25252
-             log-aeron-counters = on
-           }
-         }
-       }
-      """)
-        .withFallback(reference)
-
-      val checker = new ConfigChecker(extSys, config1, reference)
-      val warnings = checker.check().warnings
-
-      printDocWarnings(warnings)
-      assertCheckerKey(warnings, "hostname", "remote-prefer-cluster")
-      assertPath(warnings, "akka.remote.artery.canonical.hostname", "akka.actor.provider")
-
-      val config2 =
-        ConfigFactory.parseString("""akka.remote.artery.canonical.hostname = "<getHostName>" """).withFallback(config1)
-
-      val checker2 = new ConfigChecker(extSys, config2, reference)
-      val warnings2 = checker2.check().warnings
-
-      printDocWarnings(warnings2)
-      assertCheckerKey(warnings2, "hostname", "remote-prefer-cluster")
-      assertPath(warnings2, "akka.remote.artery.canonical.hostname", "akka.actor.provider")
-      assertDisabled(config2, "hostname", "remote-prefer-cluster")
-
-    }
-
     "not warn about HTTP server, client and pool specific parsing overrides" in {
       // these are brought in through some trix in akka-http
       val config = ConfigFactory

--- a/docs/src/main/paradox/config-checker.md
+++ b/docs/src/main/paradox/config-checker.md
@@ -290,20 +290,6 @@ Don't use jvm-exit-on-fatal-error=off. It's safer to shutdown the JVM in case of
 [akka.remote.netty.udp] is not a recommended transport for remote actor messages in production. Related config properties: [akka.remote.enabled-transports]. You may disable this check by adding [enabled-transports] to configuration string list akka.diagnostics.checker.disabled-checks.
 ```
 
-### hostname
-
-*If using Artery:*
-
-```
-hostname is set to <getHostAddress>, which means that `InetAddress.getLocalHost.getHostAddress` will be used to resolve the hostname. That can result in wrong hostname in some environments, such as "127.0.1.1". Define the hostname explicitly instead. On this machine `InetAddress.getLocalHost.getHostAddress` is [192.168.1.85]. Related config properties: [akka.remote.artery.canonical.hostname = <getHostAddress>]. Corresponding default values: [akka.remote.artery.canonical.hostname = <getHostAddress>]. You may disable this check by adding [hostname] to configuration string list akka.diagnostics.checker.disabled-checks.
-```
-
-or
-
-```
- hostname is set to <getHostName>, which means that `InetAddress.getLocalHost.getHostAddress` will be used to resolve the hostname. That can result in wrong hostname in some environments, such as "127.0.1.1". Define the hostname explicitly instead. On this machine `InetAddress.getLocalHost.getHostAddress` is [Johans-iMac.local]. Related config properties: [akka.remote.artery.canonical.hostname = <getHostName>]. Corresponding default values: [akka.remote.artery.canonical.hostname = <getHostAddress>]. You may disable this check by adding [hostname] to configuration string list akka.diagnostics.checker.disabled-checks.
-```
-
 ### maximum-frame-size
 
 ```


### PR DESCRIPTION
* noticed that this will always warn for the default config, which is `<getHostAddress>`
* I'm not aware of such problem, we run production systems in gcp and aws with default hostname
