### PR TITLE
Replace hardcoded repo.akka.io resolver with tokenized URLs

### DIFF
--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -24,15 +24,15 @@ Key links:
 - [ ] Update the revision in Fossa in the Akka Group for the Akka umbrella version, e.g. `22.10`. Note that the revisions for the release is udpated by Akka Group > Projects > Edit. For recent dependency updates the Fossa validation can be triggered from the GitHub actions "Dependency License Scanning".
 - [ ] Wait until [main build finished](https://github.com/akka/akka-diagnostics/actions) after merging the latest PR
 - [ ] Update the [draft release](https://github.com/akka/akka-diagnostics/releases) with the next tag version `v$VERSION$`, title and release description. Use the `Publish release` button, which will create the tag.
-- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-diagnostics/actions) for the new tag and publish artifacts to https://repo.akka.io/maven)
+- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-diagnostics/actions) for the new tag and publish artifacts to the Akka repository)
 
 ### Check availability
 
 - [ ] Check [API](https://doc.akka.io/api/akka-diagnostics/$VERSION$/) documentation
 - [ ] Check [reference](https://doc.akka.io/libraries/akka-diagnostics/$VERSION$/) documentation. Check that the reference docs were deployed and show a version warning (see section below on how to fix the version warning).
-- [ ] Check the release `mvn dependency:get -Dartifact=com.lightbend.akka:akka-diagnostics_2.13:$VERSION$`
+- [ ] Check the release using your token resolver URL from https://account.akka.io/token: `mvn dependency:get -Dartifact=com.lightbend.akka:akka-diagnostics_2.13:$VERSION$ -Dmaven.repo.remote=<token url>`
 
-### When everything is on https://repo.akka.io/maven
+### When everything is available in the Akka repository
 - [ ] Log into `gustav.akka.io` as `akkarepo`
     - [ ] If this updates the `current` version, run `./update-akka-diagnostics-current-version.sh $VERSION$`
     - [ ] otherwise check changes and commit the new version to the local git repository

--- a/docs/src/main/paradox/config-checker.md
+++ b/docs/src/main/paradox/config-checker.md
@@ -28,7 +28,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 Additionally, add the dependency as below.

--- a/docs/src/main/paradox/starvation-detector.md
+++ b/docs/src/main/paradox/starvation-detector.md
@@ -27,7 +27,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 Additionally, add the dependency as below.


### PR DESCRIPTION
Akka library artifacts are now served from a secure, per-user tokenized repository.

- Release repository: use the tokenized URL from https://account.akka.io/token
- Snapshot repository: `https://repo.akka.io/TOKEN/secure/snapshots` (replace `TOKEN` with a token from https://account.akka.io/token)

This aligns the documentation/config with the canonical form in akka-core's `project/links` page. The old non-tokenized `https://repo.akka.io/snapshots` (and `/maven`) URLs no longer work for external consumers.